### PR TITLE
Add support for ignored_paths configuration and corresponding tests

### DIFF
--- a/lib/generators/rails_performance/install/templates/initializer.rb
+++ b/lib/generators/rails_performance/install/templates/initializer.rb
@@ -21,6 +21,10 @@ RailsPerformance.setup do |config|
   # You can ignore endpoints with Rails standard notation controller#action
   # config.ignored_endpoints = ['HomeController#contact']
 
+  # You can ignore request paths by specifying the beginning of the path.
+  # For example, all routes starting with '/admin' can be ignored:
+  # config.ignored_paths = ['/admin']
+
   # store custom data for the request
   # config.custom_data_proc = proc do |env|
   #   request = Rack::Request.new(env)

--- a/lib/rails_performance.rb
+++ b/lib/rails_performance.rb
@@ -83,6 +83,12 @@ module RailsPerformance
   end
   @@ignored_endpoints = []
 
+  mattr_reader :ignored_paths
+  def RailsPerformance.ignored_paths=(paths)
+    @@ignored_paths = Set.new(paths)
+  end
+  @@ignored_paths = []
+
   # skip requests if it's inside Rails Performance view
   mattr_accessor :skip
   @@skip = false

--- a/lib/rails_performance/instrument/metrics_collector.rb
+++ b/lib/rails_performance/instrument/metrics_collector.rb
@@ -23,6 +23,7 @@ module RailsPerformance
         event = ActiveSupport::Notifications::Event.new(event_name, started, finished, event_id, payload)
 
         return if RailsPerformance.ignored_endpoints.include? "#{event.payload[:controller]}##{event.payload[:action]}"
+        return if RailsPerformance.ignored_paths.any? { |p| event.payload[:path].start_with?(p) }
 
         record = {
           controller: event.payload[:controller],

--- a/test/rails_performance_controller_test.rb
+++ b/test/rails_performance_controller_test.rb
@@ -36,6 +36,14 @@ class RailsPerformanceControllerTest < ActionDispatch::IntegrationTest
     RailsPerformance.ignored_endpoints = original_ignored_endpoints
   end
 
+  test "should respect ignored_paths configuration value" do
+    original_ignored_paths = RailsPerformance.ignored_paths
+    RailsPerformance.ignored_paths = ['/home']
+    get '/home/contact'
+    assert_equal requests_report_data.size, 0
+    RailsPerformance.ignored_paths = original_ignored_paths
+  end
+
   test "should get index" do
     setup_db
     assert_equal requests_report_data.size, 1


### PR DESCRIPTION
- Introduced a new `ignored_paths` configuration to allow ignoring requests based on URL path prefixes (e.g., '/admin').
- Updated the initializer documentation with an example for configuring `ignored_paths`.
- Added tests to ensure requests with matching paths are properly ignored.
- Retained the original `ignored_endpoints` functionality for controller#action notation while extending flexibility with URL path-based ignoring.