### PR TITLE
Fix timezone inconsistency between Time.now and Time.current in Redis…

### DIFF
--- a/lib/rails_performance/data_source.rb
+++ b/lib/rails_performance/data_source.rb
@@ -21,7 +21,7 @@ module RailsPerformance
     def db
       result = RailsPerformance::Models::Collection.new
       (0..(RailsPerformance::Utils.days + 1)).to_a.reverse.each do |e|
-        RailsPerformance::DataSource.new(q: self.q.merge({ on: (Time.current - e.days).to_date }), type: type).add_to(result)
+        RailsPerformance::DataSource.new(q: self.q.merge({ on: (Time.now - e.days).to_date }), type: type).add_to(result)
       end
       result
     end


### PR DESCRIPTION
… operations

- Replaced Time.current with Time.now to ensure that data creation and retrieval in Redis consistently respects the Rails application's time zone.
- This fixes an issue where data stored in Redis becomes unavailable around midnight due to mismatched time zone handling between storing and retrieving data.